### PR TITLE
fix: form item unregisters due to un-memoized store

### DIFF
--- a/src/components/form/context.tsx
+++ b/src/components/form/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useContext } from "react";
+import { createContext, ReactNode, useContext, useMemo } from "react";
 import { ReadOnlyUseCreateStore } from "@Utilities/store";
 import { FormFields, GenericFields, UseForm } from "./useForm";
 
@@ -18,9 +18,18 @@ export type FormProviderProps<Fields extends GenericFields> =
 
 const FormProvider = <Fields extends GenericFields>({
   children,
-  ...rest
+  register,
+  set,
+  store,
+  validation,
 }: FormProviderProps<Fields>): JSX.Element => {
-  return <FormContext.Provider value={rest}>{children}</FormContext.Provider>;
+  const context = useMemo(() => {
+    return { register, set, validation, store };
+  }, [register, set, store, validation]);
+
+  return (
+    <FormContext.Provider value={context}>{children}</FormContext.Provider>
+  );
 };
 
 const useFormContext = <

--- a/src/components/form/useForm.tsx
+++ b/src/components/form/useForm.tsx
@@ -103,8 +103,12 @@ const useForm = <Fields extends GenericFields>(): UseForm<Fields> => {
         action: ReducerActions.register,
         value: { name, value: defaultValue, defaultValue },
       });
-      return () =>
-        fields.set({ action: ReducerActions.unregister, value: { name } });
+      return () => {
+        fields.set({
+          action: ReducerActions.unregister,
+          value: { name },
+        });
+      };
     },
     [fields]
   );

--- a/src/utilities/store.ts
+++ b/src/utilities/store.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type GlobalStoreKey<Store> = {
   subscriptions: Set<(value: Store) => void>;
@@ -73,7 +73,7 @@ export const useCreateStore = <Store, Action = Partial<Store>>(
     return () => subscriptions.current.delete(cb);
   }, []);
 
-  return { get, set, subscribe };
+  return useMemo(() => ({ get, set, subscribe }), [get, set, subscribe]);
 };
 
 export type SelectorFn<Store, Selected = Store> = (


### PR DESCRIPTION
The `useCreateStore` hook was not memoizing it's return object which was causing other `useEffect`s to run when they should not be.