### PR TITLE
fix: add display name to inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ouellettec/design-system",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "author": "Christopher Ouellette <chrisryanouellette@gmail.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/src/components/inputs/checkbox/checkbox.tsx
+++ b/src/components/inputs/checkbox/checkbox.tsx
@@ -48,4 +48,6 @@ const Checkbox = ({
   );
 };
 
+Checkbox.displayName = "Checkbox";
+
 export { Checkbox };

--- a/src/components/inputs/date/date.input.tsx
+++ b/src/components/inputs/date/date.input.tsx
@@ -28,4 +28,6 @@ const DateInput = ({
   );
 };
 
+DateInput.displayName = "DateInput";
+
 export { DateInput };

--- a/src/components/inputs/index.ts
+++ b/src/components/inputs/index.ts
@@ -4,5 +4,6 @@ export * from "./checkbox";
 export * from "./text";
 export * from "./number";
 export * from "./select";
+export * from "./utilities";
 
 export type State = "disabled" | "error";

--- a/src/components/inputs/number/number.input.tsx
+++ b/src/components/inputs/number/number.input.tsx
@@ -28,4 +28,6 @@ const NumberInput = ({
   );
 };
 
+NumberInput.displayName = "NumberInput";
+
 export { NumberInput };

--- a/src/components/inputs/select/select.tsx
+++ b/src/components/inputs/select/select.tsx
@@ -67,6 +67,7 @@ const SelectInput = ({
   );
 };
 
+SelectInput.displayName = "SelectInput";
 SelectInput.Option = SelectOption;
 
 export { SelectInput };

--- a/src/components/inputs/text/text.input.tsx
+++ b/src/components/inputs/text/text.input.tsx
@@ -28,4 +28,6 @@ const TextInput = ({
   );
 };
 
+TextInput.displayName = "TextInput";
+
 export { TextInput };

--- a/src/components/inputs/utilities/errors.tsx
+++ b/src/components/inputs/utilities/errors.tsx
@@ -46,4 +46,6 @@ const Errors = ({
   );
 };
 
+Errors.displayName = "Errors";
+
 export { Errors };


### PR DESCRIPTION
Inputs needed a display name so they are rendered correctly within a `<Form.Item>`.