### PR TITLE
fix: form `onUpdate` prop needs to be in <Form> deps array

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -47,7 +47,7 @@ const Form = <Fields extends GenericFields>({
     return function FormComponentSubscriptionsCleanUp() {
       unsubscribes.forEach((fn) => fn());
     };
-  }, [form, onFinish, onFinishFailed]);
+  }, [form, onFinish, onFinishFailed, onUpdate]);
 
   return (
     <FormProvider


### PR DESCRIPTION
The `onUpdate` prop was not in the `<Form>` subscription dependency array so if it changed it would not be updated and a scale function would be called.