### PR TITLE
fix: storage not needed remove optional chaining

### DIFF
--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -25,7 +25,7 @@ export function useBrowserStorage<Store, Action = Partial<Store>>({
   }, [key, storage]);
 
   useEffect(() => {
-    const previous = storage?.getItem(key);
+    const previous = storage.getItem(key);
     const value = previous ? JSON.parse(previous) : baseInitial;
     store.set(value);
   }, [baseInitial, key, storage, store]);


### PR DESCRIPTION
`storage` is now guaranteed to be set so the optional chaining operator is not needed.