### PR TITLE
feat: collapse mount children

### DIFF
--- a/src/components/collapse/collapse.panel.tsx
+++ b/src/components/collapse/collapse.panel.tsx
@@ -12,6 +12,7 @@ export type CollapsePanelProps = HTMLAttributes<HTMLElement> & {
   element?: "div" | "section" | "aside";
   duration?: number;
   trapFocus?: boolean;
+  unmountChildren?: boolean;
   children?: ReactNode;
 };
 
@@ -23,6 +24,7 @@ const CollapsePanel = ({
   duration = 300,
   element = "div",
   trapFocus,
+  unmountChildren = true,
   ...rest
 }: CollapsePanelProps): JSX.Element => {
   const context = useCollapseContext();
@@ -56,10 +58,10 @@ const CollapsePanel = ({
   return (
     <CSSTransition
       key="collapse"
-      unmountOnExit
       nodeRef={ref}
       in={isOpen}
       timeout={duration}
+      unmountOnExit={unmountChildren}
       classNames="omlette-collapse-panel"
     >
       <Container

--- a/src/components/collapse/stories/collapse.stories.tsx
+++ b/src/components/collapse/stories/collapse.stories.tsx
@@ -1,10 +1,19 @@
+import { ControlTypes } from "@Storybook/types";
 import { BasicCollapseStory as Basic } from "./story/basic";
 
-export type CollapseControls = void;
+export type CollapseControls = { "Unmount Children": boolean };
+const commonArgs = {
+  "Unmount Children": {
+    control: { type: ControlTypes.Boolean },
+  },
+};
 
 export default {
   title: "Components/Collapse",
   parameters: { controls: { sort: "alpha" } },
 };
 
+Basic.argTypes = {
+  ...commonArgs,
+};
 export { Basic };

--- a/src/components/collapse/stories/story/basic.tsx
+++ b/src/components/collapse/stories/story/basic.tsx
@@ -1,18 +1,22 @@
+import { FC } from "react";
 import { Collapse } from "@Components/collapse/collapse";
 import { bindTemplate } from "@Storybook/types";
+import { CollapseControls } from "../collapse.stories";
 
-const BasicCollapseStory = bindTemplate(() => {
-  return (
-    <Collapse>
-      <Collapse.Trigger>
-        Expand Panel
-        <Collapse.Carrot />
-      </Collapse.Trigger>
-      <Collapse.Panel>
-        <h2>Panel Content</h2>
-      </Collapse.Panel>
-    </Collapse>
-  );
-});
+const BasicCollapseStory = bindTemplate<FC<CollapseControls>>(
+  ({ "Unmount Children": unmountChildren }) => {
+    return (
+      <Collapse>
+        <Collapse.Trigger>
+          Expand Panel
+          <Collapse.Carrot />
+        </Collapse.Trigger>
+        <Collapse.Panel unmountChildren={unmountChildren}>
+          <h2>Panel Content</h2>
+        </Collapse.Panel>
+      </Collapse>
+    );
+  }
+);
 
 export { BasicCollapseStory };


### PR DESCRIPTION
When nesting some elements, like forms, inside a collapse it is needed for the components to be mounted so they can have their data created.  