### PR TITLE
fix: move all firebase imports to lib directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ouellettec/design-system",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": "Christopher Ouellette <chrisryanouellette@gmail.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,5 +7,4 @@ export * from "./form";
 export * from "./icon";
 export * from "./inputs";
 export * from "./list";
-export * from "./user";
 export * from "./utilities";

--- a/src/components/user/index.ts
+++ b/src/components/user/index.ts
@@ -1,1 +1,0 @@
-export * from "./user-hoc";

--- a/src/lib/firebase/auth/index.ts
+++ b/src/lib/firebase/auth/index.ts
@@ -1,1 +1,3 @@
 export * from "./user";
+export * from "./useUser";
+export * from "./user-hoc";

--- a/src/lib/firebase/auth/stories/auth.stories.mdx
+++ b/src/lib/firebase/auth/stories/auth.stories.mdx
@@ -104,8 +104,7 @@ export const getServerSideProps = withAuth<Props>({
 To avoid issues with the SSR page and client page's HTML not matching, we will set the user store's `isLoggedIn` property to `true` in the module's scope.
 
 ```ts
-import { withAuth } from "@omlette-design-system/lib";
-import { withUser } from "@omlette-design-system/components";
+import { withAuth, withUser } from "@omlette-design-system/lib";
 
 export const getServerSideProps = withAuth<Props>({});
 

--- a/src/lib/firebase/auth/useUser.ts
+++ b/src/lib/firebase/auth/useUser.ts
@@ -9,8 +9,7 @@ import {
   User as FirebaseUser,
 } from "firebase/auth";
 import { useRouter } from "next/router";
-import { createGlobalStore, UseCreateStore } from "./store";
-import { isSSR } from "./ssr";
+import { createGlobalStore, UseCreateStore, isSSR } from "@Utilities";
 import {
   firebaseClient,
   User,

--- a/src/lib/firebase/auth/user-hoc.tsx
+++ b/src/lib/firebase/auth/user-hoc.tsx
@@ -1,6 +1,5 @@
 import { ComponentType } from "react";
-import { userStore } from "@Utilities/user";
-import { User } from "@Lib";
+import { User, userStore } from "@Lib";
 
 /**
  * A higher order component that handles setting the user from SSR hydrated props.

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -6,4 +6,3 @@ export * from "./ssr";
 export * from "./store";
 export * from "./storage";
 export * from "./timer";
-export * from "./user";


### PR DESCRIPTION
If Firebase was not installed in the consumer then they could not use any of the components, even if they where not using Firebase.