### PR TITLE
fix: hide closed collapse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ouellettec/design-system",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "author": "Christopher Ouellette <chrisryanouellette@gmail.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/src/components/collapse/collapse.styles.css
+++ b/src/components/collapse/collapse.styles.css
@@ -7,7 +7,7 @@
 }
 
 :where(.omlette-collapse-panel) {
-  @apply transition-transform overflow-auto shadow-md shadow-slate-100 mb-4;
+  @apply transition-transform overflow-auto shadow-md shadow-slate-100;
   background-color: var(--omlette-drawer-background-color);
   transition-duration: var(--omlette-collapse-duration);
 }
@@ -28,4 +28,18 @@
 
 :where(.omlette-collapse-carrot-enter, .omlette-collapse-carrot-enter-done) {
   transform: rotate(-180deg);
+}
+
+:where(.omlette-collapse-panel-container .omlette-collapse-panel-exit-done) {
+  height: 0;
+}
+
+/* We can remove the @supports once Firefox supports the :has feature */
+@supports selector(:has(*)) {
+  :where(.omlette-collapse-panel-container:has(.omlette-collapse-panel-exit-done)) {
+    visibility: hidden;
+  }
+  :where(.omlette-collapse-panel-container .omlette-collapse-panel-exit-done) {
+    height: initial;
+  }
 }


### PR DESCRIPTION
Elements that where positioned behind an `absolute` positioned `<Collapse.Panel>` could not be clicked on when it was closed. 

If we support `:has()` then we can use `visibility: hidden` based on if the child hidden, else we will hide it by setting the `height` to `0`.