### PR TITLE
feat: list context

### DIFF
--- a/src/components/list/context.tsx
+++ b/src/components/list/context.tsx
@@ -1,0 +1,29 @@
+import { createContext, ReactNode, useContext } from "react";
+import { ListStyle } from "./list.item";
+
+type ListContextType = {
+  listStyle?: ListStyle;
+};
+
+const ListContext = createContext<ListContextType | null>(null);
+
+type ListProviderProps = ListContextType & {
+  children?: ReactNode;
+};
+
+export function ListProvider({
+  children,
+  ...rest
+}: ListProviderProps): JSX.Element {
+  return <ListContext.Provider value={rest}>{children}</ListContext.Provider>;
+}
+
+export function useListContext(): ListContextType {
+  const context = useContext(ListContext);
+
+  if (!context) {
+    throw new Error('"useListContext" must be used within a <ListProvider>');
+  }
+
+  return context;
+}

--- a/src/components/list/list.item.tsx
+++ b/src/components/list/list.item.tsx
@@ -2,6 +2,7 @@ import { HTMLAttributes, ReactNode } from "react";
 import { concat } from "@Utilities/concat";
 import { ChildOrNull } from "@Components/utilities/ChildOrNull";
 import { Icon, IconProps } from "@Components/icon";
+import { useListContext } from "./context";
 
 export type ListStyle =
   | "bullet"
@@ -31,10 +32,12 @@ const ListItem = ({
   children,
   className,
   iconProps,
-  listStyle = "none",
+  listStyle: controlledListStyle,
   wrapperProps,
   ...rest
 }: ListItemProps): JSX.Element => {
+  const { listStyle: inheritedListStyle } = useListContext();
+  const listStyle = controlledListStyle ?? inheritedListStyle ?? "none";
   const customMarker = listStyle === "icon";
 
   const classes = concat(

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -1,10 +1,12 @@
 import { HTMLAttributes, ReactNode } from "react";
 import { concat } from "@Utilities/concat";
-import { ListItem } from "./list.item";
+import { ListItem, ListStyle } from "./list.item";
+import { ListProvider } from "./context";
 
 import "./list.styles.css";
 
 export type ListProps = HTMLAttributes<HTMLUListElement> & {
+  listStyle?: ListStyle;
   ordered?: boolean;
   children?: ReactNode;
 };
@@ -12,6 +14,7 @@ export type ListProps = HTMLAttributes<HTMLUListElement> & {
 const List = ({
   children,
   className,
+  listStyle,
   ordered,
   ...rest
 }: ListProps): JSX.Element => {
@@ -20,9 +23,11 @@ const List = ({
   const classes = concat("omlette-list", className);
 
   return (
-    <Element {...rest} className={classes}>
-      {children}
-    </Element>
+    <ListProvider listStyle={listStyle}>
+      <Element {...rest} className={classes}>
+        {children}
+      </Element>
+    </ListProvider>
   );
 };
 


### PR DESCRIPTION
Added a list context so the style could be set once in the root `<List>` and then inherited by `<List.Item>` components.