### PR TITLE
fix: hide closed collapse before it has been toggled

### DIFF
--- a/src/components/collapse/collapse.panel.tsx
+++ b/src/components/collapse/collapse.panel.tsx
@@ -68,6 +68,8 @@ const CollapsePanel = ({
         {...containerProps}
         className={concat(
           "omlette-collapse-panel-container",
+          !context.store.get().hasBeenOpened &&
+            "omlette-collapse-panel-container-unopened",
           containerProps?.className
         )}
       >

--- a/src/components/collapse/collapse.styles.css
+++ b/src/components/collapse/collapse.styles.css
@@ -30,6 +30,10 @@
   transform: rotate(-180deg);
 }
 
+:where(.omlette-collapse-panel-container-unopened) {
+  visibility: hidden;
+}
+
 :where(.omlette-collapse-panel-container .omlette-collapse-panel-exit-done) {
   height: 0;
 }

--- a/src/components/collapse/stories/collapse.stories.tsx
+++ b/src/components/collapse/stories/collapse.stories.tsx
@@ -1,7 +1,7 @@
 import { ControlTypes } from "@Storybook/types";
 import { BasicCollapseStory as Basic } from "./story/basic";
 
-export type CollapseControls = { "Unmount Children": boolean };
+export type CollapseControls = { "Unmount Children": string };
 const commonArgs = {
   "Unmount Children": {
     control: { type: ControlTypes.Boolean },

--- a/src/components/collapse/stories/story/basic.tsx
+++ b/src/components/collapse/stories/story/basic.tsx
@@ -11,7 +11,7 @@ const BasicCollapseStory = bindTemplate<FC<CollapseControls>>(
           Expand Panel
           <Collapse.Carrot />
         </Collapse.Trigger>
-        <Collapse.Panel unmountChildren={unmountChildren}>
+        <Collapse.Panel unmountChildren={unmountChildren === "true"}>
           <h2>Panel Content</h2>
         </Collapse.Panel>
       </Collapse>

--- a/src/components/collapse/useCollapse.ts
+++ b/src/components/collapse/useCollapse.ts
@@ -1,16 +1,21 @@
 import { useCallback, useMemo } from "react";
 import { useCreateStore, UseCreateStore } from "@Utilities/store";
 
+type CollapseStore = { isOpen: boolean; hasBeenOpened: boolean };
+
 export type UseCollapse = {
-  store: UseCreateStore<{ isOpen: boolean }>;
+  store: UseCreateStore<CollapseStore>;
   toggle: () => void;
 };
 
 const useCollapse = (): UseCollapse => {
-  const store = useCreateStore({ isOpen: false });
+  const store = useCreateStore<CollapseStore>({
+    isOpen: false,
+    hasBeenOpened: false,
+  });
 
   const toggle = useCallback<UseCollapse["toggle"]>(() => {
-    store.set({ isOpen: !store.get().isOpen });
+    store.set({ isOpen: !store.get().isOpen, hasBeenOpened: true });
   }, [store]);
 
   return useMemo(


### PR DESCRIPTION
The `<Collapse.Panel>` would only be hidden after the initial toggle, not on first paint. 