### PR TITLE
fix: collapse style

### DIFF
--- a/src/components/collapse/collapse.styles.css
+++ b/src/components/collapse/collapse.styles.css
@@ -7,7 +7,7 @@
 }
 
 :where(.omlette-collapse-panel) {
-  @apply transition-transform overflow-auto shadow-md shadow-slate-100;
+  @apply transition-transform overflow-auto shadow-md shadow-slate-100 z-10;
   background-color: var(--omlette-drawer-background-color);
   transition-duration: var(--omlette-collapse-duration);
 }


### PR DESCRIPTION
`<Collapse.Panel>` need a z-index to stay on top of other content.