### PR TITLE
fix: firebase auth

### DIFF
--- a/src/lib/firebase/auth/stories/auth.stories.mdx
+++ b/src/lib/firebase/auth/stories/auth.stories.mdx
@@ -37,16 +37,19 @@ If the request returns successfully the function will call the backend api route
 
 Our backend will need to define two routes for signing the user in and out. The example below will be for NextJS but will work with Express or any other backend library.
 
+If you are using NextJS create a file called `login.ts` in the `pages/api/` directory.
+
 ```ts
+// pages/api/login.ts
 import { NextApiRequest, NextApiResponse } from "next";
-import { authenticate } from "@omlette-design-system/lib";
+import { unauthenticate } from "@ouellettec/design-system/ssr";
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
   try {
-    await authenticate(req, res);
+    await authenticate({ req }, res);
     return res.status(200).json({ status: true });
   } catch (e) {
     // Log to your analytics service provider here
@@ -62,8 +65,9 @@ This endpoint will ensure the token passed two it is valid and set a session coo
 Logging out is just as simple.
 
 ```ts
+// pages/api/logout.ts
 import { NextApiRequest, NextApiResponse } from "next";
-import { unauthenticate } from "@omlette-design-system/lib";
+import { unauthenticate } from "@ouellettec/design-system/ssr";
 
 async function handler(
   req: NextApiRequest,
@@ -90,7 +94,7 @@ import { withAuth } from "@omlette-design-system/lib";
 
 export const getServerSideProps = withAuth<Props>({
   whenUnauthed: "redirect",
-  unauthedRedirect: "/login", // Optional
+  unauthedRedirectRoute: "/login", // Optional
 })(async ({ ctx, user }) => {
   // User has been authenticated and can see the route
   return {

--- a/src/lib/firebase/auth/token.ts
+++ b/src/lib/firebase/auth/token.ts
@@ -1,26 +1,27 @@
 import { GetServerSidePropsContext, NextApiRequest } from "next";
 import { parseCookies } from "nookies";
 import { DecodedIdToken, getAuth } from "firebase-admin/auth";
+import { firebaseAdmin } from "../ssr";
 import { normalizeUser, User } from "./user";
 
 export async function verifyAuthenticationToken(
   token: string
 ): Promise<DecodedIdToken> {
-  const firebaseAdminAuth = getAuth();
+  const firebaseAdminAuth = getAuth(firebaseAdmin);
   return await firebaseAdminAuth.verifyIdToken(token, true);
 }
 
 export async function verifySessionToken(
   token: string
 ): Promise<DecodedIdToken> {
-  const firebaseAdminAuth = getAuth();
+  const firebaseAdminAuth = getAuth(firebaseAdmin);
   return await firebaseAdminAuth.verifySessionCookie(token, true);
 }
 
 export async function getUserFromTokenDecodedAuthenticationToken(
   token: DecodedIdToken
 ): Promise<User> {
-  const firebaseAdminAuth = getAuth();
+  const firebaseAdminAuth = getAuth(firebaseAdmin);
   const user = await firebaseAdminAuth.getUser(token.uid);
   return normalizeUser(user);
 }

--- a/src/lib/firebase/auth/useUser.ts
+++ b/src/lib/firebase/auth/useUser.ts
@@ -82,12 +82,12 @@ export async function loginUserFromAuthChange(
 }
 
 export async function login(): Promise<void> {
-  const auth = getAuth();
+  const auth = getAuth(firebaseClient);
   await signInWithRedirect(auth, provider);
 }
 
 export async function logout(): Promise<void> {
-  const auth = getAuth();
+  const auth = getAuth(firebaseClient);
   signOut(auth);
   await fetch("/api/logout");
   unsubscribeFromAuthChanges();

--- a/src/lib/firebase/initialize/client.ts
+++ b/src/lib/firebase/initialize/client.ts
@@ -14,15 +14,17 @@ export type InitializeFirebaseClientArgs = {
 };
 
 export function initializeFirebaseClient(
-  args: InitializeFirebaseClientArgs
-): FirebaseApp | void {
+  args: InitializeFirebaseClientArgs,
+  init: typeof initializeApp = initializeApp
+): FirebaseApp {
   if (!isSSR()) {
     if (!getApps().length) {
-      firebaseClient = initializeApp(args);
+      firebaseClient = init(args);
       subs.forEach((sub) => sub());
       return firebaseClient;
     }
   }
+  return firebaseClient;
 }
 
 /**


### PR DESCRIPTION
- `getAuth` functions needed to `firebaseClient` to ensure they get the correct auth instance.
- Updated documentation.
- Allow init function to be passed to client init.