### PR TITLE
fix: global store set creates new value

### DIFF
--- a/src/utilities/store.ts
+++ b/src/utilities/store.ts
@@ -33,7 +33,8 @@ export const createGlobalStore = <T>(value: T): UseCreateStore<T> => {
 
   const get: UseCreateStore<T>["get"] = () => globalStore.get(key);
   const set: UseCreateStore<T>["set"] = (value) => {
-    globalStore.set(key, value);
+    const prev = globalStore.get(key);
+    globalStore.set(key, { ...prev, ...value });
     key.subscriptions.forEach((sub) => sub(get()));
   };
   const subscribe: UseCreateStore<T>["subscribe"] = (cb) => {


### PR DESCRIPTION
The global store set arguments would over write the previous value. Now it is merged via a spread overpator.