### PR TITLE
fix: global store subscriptions not running

### DIFF
--- a/src/utilities/store.ts
+++ b/src/utilities/store.ts
@@ -43,6 +43,13 @@ export const createGlobalStore = <Store, Action = Partial<Store>>(
   };
   const subscribe: UseCreateStore<Store>["subscribe"] = (cb) => {
     key.subscriptions.add(cb);
+    /*
+    Call the sub function once the useStore subscribes to a global store
+    This ensure that if an update comes in after the lazy initializer useState
+    function runs but before the useEffect runs to subscribe to the changes that
+    the update is still dispatched to the subscriber.
+    */
+    cb(get());
     return () => key.subscriptions.delete(cb);
   };
   return { get, set, subscribe };


### PR DESCRIPTION
When there was an update to a global store during the first render of a component, the update would not get dispatched to the subscriber.
The situation was, 
1. A component would mount running the `useState`'s lazy initializer.
2. The application would call `set` on a global store.
3. The component's `useEffect` would run adding the subscription to the store.

Since the update occurred  before the `useEffect` ran the component would never receive the update.