### PR TITLE
fix: drawer trigger typing

### DIFF
--- a/src/components/drawer/drawer.trigger.tsx
+++ b/src/components/drawer/drawer.trigger.tsx
@@ -4,7 +4,9 @@ import { drawerStore } from "./store";
 
 export type DrawerTriggerProps = ButtonProps & {
   drawer: string;
-  element?: FC;
+  // Allow any functional component to be passed as the drawer trigger
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  element?: FC<any>;
   children?: ReactNode;
   onBeforeClose?: (e: MouseEvent<HTMLElement>) => void;
   onAfterClose?: (e: MouseEvent<HTMLElement>) => void;


### PR DESCRIPTION
The `<Drawer.Trigger>` component could not accept any elements via the `element` prop because the type was set to `FC`.