### PR TITLE
feat: form set default value

### DIFF
--- a/src/components/form/reducers.ts
+++ b/src/components/form/reducers.ts
@@ -4,6 +4,7 @@ export enum ReducerActions {
   register = "register",
   unregister = "unregister",
   set = "set",
+  setDefault = "setDefault",
   validate = "validate",
 }
 
@@ -80,6 +81,34 @@ const set = (
   };
 };
 
+type SetDefaultFieldAction = {
+  action: ReducerActions.setDefault;
+  value: {
+    name: string;
+    default: unknown;
+  };
+};
+
+const setDefault = (
+  fields: FormFields<GenericFields>,
+  action: SetDefaultFieldAction
+): FormFields<GenericFields> => {
+  const field = fields[action.value.name];
+
+  if (!field) {
+    throw new Error(
+      `Field "${action.value.name}" set it's default value but the field does not exist.`
+    );
+  }
+
+  field.defaultValue = action.value.default;
+
+  return {
+    ...fields,
+    [action.value.name]: field,
+  };
+};
+
 type ValidateFieldAction = {
   action: ReducerActions.validate;
   value: {
@@ -111,6 +140,7 @@ const validate = (
 export type FormFieldsActions =
   | RegisterFieldAction
   | SetFieldAction
+  | SetDefaultFieldAction
   | UnRegisterFieldAction
   | ValidateFieldAction;
 
@@ -123,6 +153,7 @@ const reducers: {
   [ReducerActions.register]: register,
   [ReducerActions.unregister]: unregister,
   [ReducerActions.set]: set,
+  [ReducerActions.setDefault]: setDefault,
   [ReducerActions.validate]: validate,
 };
 

--- a/src/components/form/stories/form.stories.mdx
+++ b/src/components/form/stories/form.stories.mdx
@@ -165,7 +165,7 @@ With the `form` variable we can call a handful of methods to manipulate the form
 ```tsx
 useEffect(() => {
   const username = localStorage.get("username");
-  username && form.set("username", username);
+  username && form.setDefault("username", username);
 }, [form]);
 ```
 

--- a/src/components/form/stories/story/basic.tsx
+++ b/src/components/form/stories/story/basic.tsx
@@ -16,11 +16,12 @@ import { FormControls } from "../form.stories";
 type BasicForm = {
   firstName: string;
   password: string;
-  amount: string;
+  amount: number;
   date: string;
   select: string;
   multi: string[];
   termsAndConditions: boolean;
+  file: FileList;
 };
 
 const firstNameValidation: Validation<BasicForm["firstName"]> = (
@@ -64,7 +65,12 @@ const BasicFormStory = bindTemplate<FC<FormControls<BasicForm>>>((props) => {
   return (
     <Container placement="center">
       <Form {...props} form={form} className="light w-72">
-        <Form.Item required name="firstName" validation={firstNameValidation}>
+        <Form.Item
+          required
+          name="firstName"
+          defaultValue="Omlette"
+          validation={firstNameValidation}
+        >
           <TextInput label="First Name" />
         </Form.Item>
         <Form.Item required name="password" validation={passwordValidation}>
@@ -90,7 +96,7 @@ const BasicFormStory = bindTemplate<FC<FormControls<BasicForm>>>((props) => {
           </SelectInput>
         </Form.Item>
         <Form.Item name="multi">
-          <SelectInput multiple label="Fun Programing Languages">
+          <SelectInput multiple label="Fun Programming Languages">
             <SelectInput.Option value="js">JS</SelectInput.Option>
             <SelectInput.Option value="dotnet">DotNet</SelectInput.Option>
             <SelectInput.Option value="groovy">Groovy</SelectInput.Option>

--- a/src/components/form/useForm.tsx
+++ b/src/components/form/useForm.tsx
@@ -71,12 +71,35 @@ export type UseForm<Fields extends GenericFields> = {
   ) => () => void;
   /**
    * Set's the field value in the store and marks it as touched.
+   *
+   * Note: This will NOT cause the form field to update.
+   * If a field needs to display the value use `setDefault` instead.
    */
   set: <K extends keyof Fields>(
     name: Extract<K, string>,
     value: Fields[K]
   ) => void;
+  /**
+   * Sets the default value for a form field and updates the form state.
+   * This will not call the subscribers to the from state.
+   */
+  setDefault: <K extends keyof Fields>(
+    name: Extract<K, string>,
+    value: Fields[K]
+  ) => void;
+  /**
+   * Sets the values for multiple fields. Each field will trigger a call to the form
+   * subscribers.
+   *
+   * Note: This will NOT cause the form field to update.
+   * If a field needs to display the value use `setManyDefault` instead.
+   */
   setMany: (fields: Partial<Fields>) => void;
+  /**
+   * Sets the default values for multiple form fields and updates the form state.
+   * This will not call the subscribers to the from state.
+   */
+  setManyDefault: (fields: Partial<Fields>) => void;
   /**
    * Adds a validation function to a field.
    * Returns the cleanup function to remove the function so
@@ -148,6 +171,19 @@ const useForm = <Fields extends GenericFields>(): UseForm<Fields> => {
     [fields]
   );
 
+  const setDefault = useCallback<UseForm<Fields>["setDefault"]>(
+    (name, value) => {
+      fields.set({
+        action: ReducerActions.setDefault,
+        value: {
+          name,
+          default: value,
+        },
+      });
+    },
+    [fields]
+  );
+
   const setMany = useCallback<UseForm<Fields>["setMany"]>(
     (values) => {
       Object.entries(values).forEach(([name, value]) => {
@@ -158,6 +194,18 @@ const useForm = <Fields extends GenericFields>(): UseForm<Fields> => {
         subscriptions.current.update.forEach((sub) =>
           sub(name, value, fields.get())
         );
+      });
+    },
+    [fields]
+  );
+
+  const setManyDefault = useCallback<UseForm<Fields>["setManyDefault"]>(
+    (values) => {
+      Object.entries(values).forEach(([name, value]) => {
+        fields.set({
+          action: ReducerActions.setDefault,
+          value: { name, default: value },
+        });
       });
     },
     [fields]
@@ -259,7 +307,9 @@ const useForm = <Fields extends GenericFields>(): UseForm<Fields> => {
       fields,
       register,
       set,
+      setDefault,
       setMany,
+      setManyDefault,
       validation,
       validate,
       submit,
@@ -270,7 +320,9 @@ const useForm = <Fields extends GenericFields>(): UseForm<Fields> => {
       fields,
       register,
       set,
+      setDefault,
       setMany,
+      setManyDefault,
       validation,
       validate,
       submit,

--- a/src/components/inputs/select/select.option.tsx
+++ b/src/components/inputs/select/select.option.tsx
@@ -12,4 +12,6 @@ const SelectOption = ({
   return <option {...rest}>{children}</option>;
 };
 
+SelectOption.displayName = "SelectOption";
+
 export { SelectOption };

--- a/src/components/inputs/select/select.tsx
+++ b/src/components/inputs/select/select.tsx
@@ -1,6 +1,14 @@
-import { OptionHTMLAttributes, ReactNode, SelectHTMLAttributes } from "react";
+import {
+  Children,
+  OptionHTMLAttributes,
+  ReactNode,
+  SelectHTMLAttributes,
+  cloneElement,
+  isValidElement,
+} from "react";
 import { concat } from "@Utilities/concat";
 import { ChildOrNull } from "@Components/utilities/ChildOrNull";
+import { isElement } from "@Utilities/react";
 import { State } from "..";
 import { Errors, ErrorsProps, Label, LabelProps } from "../utilities";
 import { SelectOption } from "./select.option";
@@ -55,11 +63,27 @@ const SelectInput = ({
         )}
       >
         <ChildOrNull condition={!multiple && !!emptyOption}>
-          <SelectOption {...emptyOptionProps} value="">
+          <SelectOption
+            {...emptyOptionProps}
+            value=""
+            selected={!inputProps?.defaultValue}
+            disabled
+            hidden
+          >
             {emptyOptionText}
           </SelectOption>
         </ChildOrNull>
-        {children}
+        {Children.map(children, function (child) {
+          if (isValidElement(child)) {
+            if (isElement(child, ["SelectOption"])) {
+              return cloneElement(child, {
+                ...child.props,
+                selected: inputProps?.defaultValue === child.props.value,
+              });
+            }
+          }
+          return child;
+        })}
       </select>
       <Errors {...errorProps} />
     </>


### PR DESCRIPTION
- Add the `setDefault` and `setDefaultMany` methods.
- These methods allow the app to update a form field with an initial ( default ) value and display it in a form field.