### PR TITLE
fix: drawer-store-export

### DIFF
--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -1,3 +1,4 @@
 export { Drawer } from "./drawer";
+export { drawerStore } from "./store";
 export type { DrawerPanelProps } from "./drawer.panel";
 export type { DrawerTriggerProps } from "./drawer.trigger";


### PR DESCRIPTION
Export the drawer store so consumers can programmatically close the drawer.